### PR TITLE
added support for multiple GA trackers

### DIFF
--- a/GBAnalytics.podspec
+++ b/GBAnalytics.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'GBAnalytics'
-  s.version      = '2.8.1'
+  s.version      = '2.9.0'
   s.summary      = 'Abstracts away different analytics networks and provides a unified simple interface.'
   s.homepage     = 'https://github.com/lmirosevic/GBAnalytics'
   s.license      = 'Apache License, Version 2.0'


### PR DESCRIPTION
https://developers.google.com/analytics/devguides/collection/ios/v3/advanced#multiple-trackers

To use multiple trackers just call `-connectNetwork:withCredentials:` for every tracker id
